### PR TITLE
Add a basic Dockerfile to execute datadog-sidekiq in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine:edge AS development
+RUN apk add --no-cache gcc musl-dev rust cargo openssl-dev
+
+ENV APP_HOME /tmp/datadog-sidekiq
+RUN mkdir -p $APP_HOME/src
+WORKDIR $APP_HOME
+
+COPY Cargo.toml $APP_HOME
+COPY src $APP_HOME/src
+RUN cargo build --release
+
+FROM alpine:edge
+RUN apk add --no-cache openssl gcc
+
+COPY --from=development /tmp/datadog-sidekiq/target/release/datadog-sidekiq /usr/bin/
+
+CMD /usr/bin/datadog-sidekiq


### PR DESCRIPTION
Our infra is Docker based and as such it's much easier for us to run your integration inside a container.

To make that easier for the next person, I've added a Dockerfile which will allow someone to build their own Docker image.

If you like, you could also add this to Docker Hub and have the image automatically build when code is updated.

Thanks for creating this integration!